### PR TITLE
MAM-35: Create share sheet that shows session code

### DIFF
--- a/mamba/mamba.xcodeproj/project.pbxproj
+++ b/mamba/mamba.xcodeproj/project.pbxproj
@@ -60,6 +60,10 @@
 		269F557D24BC302500EEC682 /* DevelopmentNetworkEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269F557C24BC302500EEC682 /* DevelopmentNetworkEnvironment.swift */; };
 		26E11B3624D429FF00C50F43 /* IntegerTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E11B3524D429FF00C50F43 /* IntegerTextField.swift */; };
 		26F98A4F24D9613B007CA2B8 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F98A4E24D9613B007CA2B8 /* LoadingView.swift */; };
+		26F98A5124D96A52007CA2B8 /* PlanningHostSessionStartShareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F98A5024D96A52007CA2B8 /* PlanningHostSessionStartShareView.swift */; };
+		26F98A5324D96CAE007CA2B8 /* SessionCodeText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F98A5224D96CAE007CA2B8 /* SessionCodeText.swift */; };
+		26F98A5524D96EF7007CA2B8 /* CodeText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F98A5424D96EF7007CA2B8 /* CodeText.swift */; };
+		26F98A5724D97ACA007CA2B8 /* DoneBarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F98A5624D97ACA007CA2B8 /* DoneBarButton.swift */; };
 		ED36B44D24BCCDD5007FF62E /* PlanningCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED36B44C24BCCDD5007FF62E /* PlanningCommand.swift */; };
 		ED38EABF24AE5C4800564F85 /* Array+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED38EABE24AE5C4800564F85 /* Array+Extensions.swift */; };
 		ED38EACD24AE60A900564F85 /* PlanningHostSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED38EACC24AE60A800564F85 /* PlanningHostSetupView.swift */; };
@@ -152,6 +156,10 @@
 		269F557C24BC302500EEC682 /* DevelopmentNetworkEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevelopmentNetworkEnvironment.swift; sourceTree = "<group>"; };
 		26E11B3524D429FF00C50F43 /* IntegerTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegerTextField.swift; sourceTree = "<group>"; };
 		26F98A4E24D9613B007CA2B8 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
+		26F98A5024D96A52007CA2B8 /* PlanningHostSessionStartShareView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanningHostSessionStartShareView.swift; sourceTree = "<group>"; };
+		26F98A5224D96CAE007CA2B8 /* SessionCodeText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCodeText.swift; sourceTree = "<group>"; };
+		26F98A5424D96EF7007CA2B8 /* CodeText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeText.swift; sourceTree = "<group>"; };
+		26F98A5624D97ACA007CA2B8 /* DoneBarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoneBarButton.swift; sourceTree = "<group>"; };
 		ED36B44C24BCCDD5007FF62E /* PlanningCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanningCommand.swift; sourceTree = "<group>"; };
 		ED38EABE24AE5C4800564F85 /* Array+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Extensions.swift"; sourceTree = "<group>"; };
 		ED38EACC24AE60A800564F85 /* PlanningHostSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanningHostSetupView.swift; sourceTree = "<group>"; };
@@ -272,6 +280,7 @@
 			children = (
 				263ECA4224D18BE600EEAB1E /* RoundedButton.swift */,
 				263ECA4C24D1943400EEAB1E /* CancelBarButton.swift */,
+				26F98A5624D97ACA007CA2B8 /* DoneBarButton.swift */,
 			);
 			path = Button;
 			sourceTree = "<group>";
@@ -280,6 +289,8 @@
 			isa = PBXGroup;
 			children = (
 				263ECA4524D18D4200EEAB1E /* TitleText.swift */,
+				26F98A5224D96CAE007CA2B8 /* SessionCodeText.swift */,
+				26F98A5424D96EF7007CA2B8 /* CodeText.swift */,
 			);
 			path = Text;
 			sourceTree = "<group>";
@@ -449,6 +460,7 @@
 				269CA06724D931ED000F42B9 /* PlanningHostSessionLandingView.swift */,
 				269CA0DF24D9479A000F42B9 /* PlanningHostParticipantRowView.swift */,
 				269CA0E124D947EA000F42B9 /* PlanningHostNoneStateCardView.swift */,
+				26F98A5024D96A52007CA2B8 /* PlanningHostSessionStartShareView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -544,9 +556,9 @@
 		ED38EAC224AE605800564F85 /* Host */ = {
 			isa = PBXGroup;
 			children = (
-				269CA06624D931C5000F42B9 /* Session Landing */,
 				26018A2224B49C2300C8B268 /* Start Session Setup */,
 				263ECA5624D29CF800EEAB1E /* Card Selection */,
+				269CA06624D931C5000F42B9 /* Session Landing */,
 			);
 			path = Host;
 			sourceTree = "<group>";
@@ -775,11 +787,13 @@
 				ED83E28924C46F3A00FCAB27 /* NetworkError.swift in Sources */,
 				26772AF624B4A4DC003FB1A4 /* PlanningHostSetupViewModel.swift in Sources */,
 				269F557D24BC302500EEC682 /* DevelopmentNetworkEnvironment.swift in Sources */,
+				26F98A5724D97ACA007CA2B8 /* DoneBarButton.swift in Sources */,
 				ED9D447B24AE4BEA00034216 /* LandingItem.swift in Sources */,
 				26772B0224B4ACC4003FB1A4 /* ClearableTextField.swift in Sources */,
 				263ECC2424D40CBC00EEAB1E /* JoinSessionCommand.swift in Sources */,
 				269CA0DE24D93E00000F42B9 /* HCardView.swift in Sources */,
 				2661E01D24BC931C00D46119 /* WebSocketHandler.swift in Sources */,
+				26F98A5524D96EF7007CA2B8 /* CodeText.swift in Sources */,
 				ED38EAD624AE64EC00564F85 /* NavigationHost.swift in Sources */,
 				ED38EACF24AE60B300564F85 /* PlanningJoinSetupView.swift in Sources */,
 				263ECA4624D18D4200EEAB1E /* TitleText.swift in Sources */,
@@ -824,8 +838,10 @@
 				263ECA5A24D29D3000EEAB1E /* PlanningHostAvailableCardsViewModel.swift in Sources */,
 				261E1ED524A48AB700937D89 /* SceneDelegate.swift in Sources */,
 				26F98A4F24D9613B007CA2B8 /* LoadingView.swift in Sources */,
+				26F98A5324D96CAE007CA2B8 /* SessionCodeText.swift in Sources */,
 				26772B0424B4ADDF003FB1A4 /* DefaultStyle.swift in Sources */,
 				269F557624BC2EF300EEC682 /* URLCenter+Planning.swift in Sources */,
+				26F98A5124D96A52007CA2B8 /* PlanningHostSessionStartShareView.swift in Sources */,
 				263ECA4F24D1952500EEAB1E /* SelectCardsButton.swift in Sources */,
 				ED38EAD424AE643500564F85 /* NavigationStack.swift in Sources */,
 				261E1ED724A48AB700937D89 /* LandingView.swift in Sources */,

--- a/mamba/mamba/Landing/Views/LandingView.swift
+++ b/mamba/mamba/Landing/Views/LandingView.swift
@@ -52,11 +52,11 @@ struct LandingView: View {
     private func landingItemTapped(_ item: LandingItem) {
         switch item {
         case .planningHost:
-            self.navigation.modal(AnyView(PlanningHostSetupView(showSheet: self.$navigation.showSheet)), colorScheme: .planning)
-            self.navigation.showSheet.toggle()
+            navigation.modal(AnyView(PlanningHostSetupView(showSheet: $navigation.showSheet)), colorScheme: .planning)
+            navigation.showSheet.toggle()
         case .planningJoin:
-            self.navigation.modal(AnyView(PlanningJoinSetupView(showSheet: self.$navigation.showSheet)), colorScheme: .planning)
-            self.navigation.showSheet.toggle()
+            navigation.modal(AnyView(PlanningJoinSetupView(showSheet: $navigation.showSheet)), colorScheme: .planning)
+            navigation.showSheet.toggle()
         default:
             return
         }

--- a/mamba/mamba/Planning/Host/Session Landing/ViewModels/PlanningHostSessionLandingViewModel.swift
+++ b/mamba/mamba/Planning/Host/Session Landing/ViewModels/PlanningHostSessionLandingViewModel.swift
@@ -13,10 +13,12 @@ class PlanningHostSessionLandingViewModel: ObservableObject {
     private var service: PlanningHostSessionLandingServiceProtocol
     private var cancellable: AnyCancellable?
     private var availableCards: [PlanningCard]
-    private(set) var sessionCode: String?
+    private var hasShownInitialShareModal: Bool = false
+    private(set) var sessionCode: String = ""
     @Published var state: PlanningSessionLandingState = .loading
     @Published var sessionName: String
     @Published var participants = [PlanningParticipant]()
+    @Published var showInitialShareModal: Bool = false
     
     init(sessionName: String, availableCards: [PlanningCard]) {
         self.service = PlanningHostSessionLandingService()
@@ -53,6 +55,12 @@ class PlanningHostSessionLandingViewModel: ObservableObject {
         case .noneState(let message):
             self.state = .none
             parseStateMessage(message)
+            
+            if !showInitialShareModal {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                    self.showInitialShareModal = true
+                }
+            }
         case .votingState(let message):
             self.state = .voting
             parseStateMessage(message)
@@ -66,6 +74,6 @@ class PlanningHostSessionLandingViewModel: ObservableObject {
     
     private func parseStateMessage(_ message: PlanningSessionStateMessage) {
         self.participants = message.participants
-        self.sessionCode = message.sessionName
+        self.sessionCode = message.sessionCode
     }
 }

--- a/mamba/mamba/Planning/Host/Session Landing/ViewModels/PlanningHostSessionLandingViewModel.swift
+++ b/mamba/mamba/Planning/Host/Session Landing/ViewModels/PlanningHostSessionLandingViewModel.swift
@@ -13,7 +13,6 @@ class PlanningHostSessionLandingViewModel: ObservableObject {
     private var service: PlanningHostSessionLandingServiceProtocol
     private var cancellable: AnyCancellable?
     private var availableCards: [PlanningCard]
-    private var hasShownInitialShareModal: Bool = false
     private(set) var sessionCode: String = ""
     @Published var state: PlanningSessionLandingState = .loading
     @Published var sessionName: String

--- a/mamba/mamba/Planning/Host/Session Landing/Views/PlanningHostSessionLandingView.swift
+++ b/mamba/mamba/Planning/Host/Session Landing/Views/PlanningHostSessionLandingView.swift
@@ -24,6 +24,9 @@ struct PlanningHostSessionLandingView: View {
             
             if self.viewModel.state == .loading {
                 LoadingView(title: "PLANNING_HOST_LANDING_CONNECTING_TITLE")
+                    .onAppear {
+                        self.viewModel.startSession()
+                    }
             }
             
             if self.viewModel.state != .loading {
@@ -31,19 +34,28 @@ struct PlanningHostSessionLandingView: View {
                     PlanningHostNoneStateCardView(title: self.viewModel.sessionName) {
                         self.addTicket()
                     }
+                    .onReceive(self.viewModel.$showInitialShareModal, perform: { shouldShow in
+                        if shouldShow {
+                            self.showShareModal()
+                        }
+                    })
                 }
                 
                 ForEach(self.viewModel.participants) { participant in
                     PlanningHostParticipantRowView(participant: participant)
                 }
             }
-        }.onAppear{
-            self.viewModel.startSession()
         }
     }
     
     private func addTicket() {
         //TODO: MAM-31
+    }
+    
+    private func showShareModal() {
+        let shareView = PlanningHostSessionStartShareView(sessionCode: viewModel.sessionCode, showSheet: $navigation.showSheet)
+        navigation.modal(AnyView(shareView))
+        navigation.showSheet = true
     }
 }
 

--- a/mamba/mamba/Planning/Host/Session Landing/Views/PlanningHostSessionStartShareView.swift
+++ b/mamba/mamba/Planning/Host/Session Landing/Views/PlanningHostSessionStartShareView.swift
@@ -1,0 +1,42 @@
+//
+//  PlanningHostSessionStartShareView.swift
+//  mamba
+//
+//  Created by Armand Kamffer on 2020/08/04.
+//  Copyright © 2020 Armand Kamffer. All rights reserved.
+//
+
+import SwiftUI
+
+struct PlanningHostSessionStartShareView: View {
+    let sessionCode: String
+    @Binding var showSheet: Bool
+    
+    var body: some View {
+        NavigationView {
+            VStack {
+                VCardView {
+                    TitleText(titleKey: "PLANNING_HOST_LANDING_SESSION_SHARE_MODAL_CODE_TITLE")
+                        .padding(leading: 20, top: 20, trailing: 20)
+                    
+                    SessionCodeText(sessionCode: self.sessionCode)
+                        .padding(leading: 20, top: 40, bottom: 20, trailing: 20)
+                }
+                Spacer()
+            }
+            .navigationBarTitle("PLANNING_HOST_LANDING_SESSION_SHARE_MODAL_TITLE", displayMode: .inline)
+            .navigationBarItems(trailing:
+                DoneBarButton {
+                    self.showSheet.toggle()
+                }
+            )
+        }
+        .navigationViewStyle(StackNavigationViewStyle())
+    }
+}
+
+struct PlanningHostSessionStartShareView_Previews: PreviewProvider {
+    static var previews: some View {
+        PlanningHostSessionStartShareView(sessionCode: "000000", showSheet: .constant(true))
+    }
+}

--- a/mamba/mamba/Resources/Localizable.strings
+++ b/mamba/mamba/Resources/Localizable.strings
@@ -4,7 +4,6 @@
 "SOME" = "Some";
 "NONE" = "None";
 "DONE" = "Done";
-"SHARE_BUTTON_TITLE" = "􀈂 Share";
 
 // MARK: - Landing screen
 "LANDING_PLANNING_HOST" = "HOST PLANNING";

--- a/mamba/mamba/Resources/Localizable.strings
+++ b/mamba/mamba/Resources/Localizable.strings
@@ -3,6 +3,8 @@
 "ALL" = "All";
 "SOME" = "Some";
 "NONE" = "None";
+"DONE" = "Done";
+"SHARE_BUTTON_TITLE" = "􀈂 Share";
 
 // MARK: - Landing screen
 "LANDING_PLANNING_HOST" = "HOST PLANNING";
@@ -20,7 +22,8 @@
 "PLANNING_HOST_LANDING_ADD_TICKET_BUTTON_TITLE" = "ADD TICKET";
 "PLANNING_HOST_LANDING_NONE_STATE_DESCRIPTION" = "To start voting on tickets, you need to add a ticket.";
 "PLANNING_HOST_LANDING_CONNECTING_TITLE" = "Connecting...";
-
+"PLANNING_HOST_LANDING_SESSION_SHARE_MODAL_TITLE" = "Share session";
+"PLANNING_HOST_LANDING_SESSION_SHARE_MODAL_CODE_TITLE" = "Session Code";
 
 // MARK: - Planning join
 "PLANNING_JOIN_TITLE" = "Join planning";

--- a/mamba/mamba/Styling/Components/Button/DoneBarButton.swift
+++ b/mamba/mamba/Styling/Components/Button/DoneBarButton.swift
@@ -1,34 +1,34 @@
 //
-//  CancelBarButton.swift
+//  DoneBarButton.swift
 //  mamba
 //
-//  Created by Armand Kamffer on 2020/07/29.
+//  Created by Armand Kamffer on 2020/08/04.
 //  Copyright © 2020 Armand Kamffer. All rights reserved.
 //
 
 import SwiftUI
 
-struct CancelBarButton: View {
+struct DoneBarButton: View {
     let action: () -> Void
     
     var body: some View {
         Button(action: {
             self.action()
         }) {
-            Text("CANCEL")
+            Text("DONE")
         }
     }
 }
 
-struct CancelBarButton_Previews: PreviewProvider {
+struct DoneBarButton_Previews: PreviewProvider {
     static var previews: some View {
         Group {
-            CancelBarButton {}
+            DoneBarButton {}
                 .environment(\.colorScheme, .light)
                 .previewDisplayName("Light mode")
                 .padding()
             
-            CancelBarButton {}
+            DoneBarButton {}
                 .environment(\.colorScheme, .dark)
                 .previewDisplayName("Dark mode")
                 .padding()

--- a/mamba/mamba/Styling/Components/Text/CodeText.swift
+++ b/mamba/mamba/Styling/Components/Text/CodeText.swift
@@ -1,0 +1,38 @@
+//
+//  CodeText.swift
+//  mamba
+//
+//  Created by Armand Kamffer on 2020/08/04.
+//  Copyright © 2020 Armand Kamffer. All rights reserved.
+//
+
+import SwiftUI
+
+struct CodeText: View {
+    let value: String
+    
+    var body: some View {
+        Text(value)
+            .font(.system(size: 25))
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .foregroundColor(DefaultStyle.shared.systemGray4)
+                    .frame(minWidth: 38, minHeight: 45)
+            )
+            .frame(minWidth: 38, minHeight: 45)
+    }
+}
+
+struct CodeText_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            CodeText(value: "0")
+                .environment(\.colorScheme, .light)
+                .previewDisplayName("Light mode")
+            CodeText(value: "1")
+                .environment(\.colorScheme, .dark)
+                .previewDisplayName("Dark mode")
+                .background(Color.black)
+        }.previewLayout(.sizeThatFits)
+    }
+}

--- a/mamba/mamba/Styling/Components/Text/SessionCodeText.swift
+++ b/mamba/mamba/Styling/Components/Text/SessionCodeText.swift
@@ -1,0 +1,40 @@
+//
+//  SessionCodeText.swift
+//  mamba
+//
+//  Created by Armand Kamffer on 2020/08/04.
+//  Copyright © 2020 Armand Kamffer. All rights reserved.
+//
+
+import SwiftUI
+
+struct SessionCodeText: View {
+    let sessionCode: String
+    var sessionCodeArray: [String] {
+        sessionCode.map { String($0) }
+    }
+    var body: some View {
+        HStack(alignment: .center, spacing: 15) {
+            CodeText(value: self.sessionCodeArray.element(at: 0) ?? "")
+            CodeText(value: self.sessionCodeArray.element(at: 1) ?? "")
+            CodeText(value: self.sessionCodeArray.element(at: 2) ?? "")
+            CodeText(value: self.sessionCodeArray.element(at: 3) ?? "")
+            CodeText(value: self.sessionCodeArray.element(at: 4) ?? "")
+            CodeText(value: self.sessionCodeArray.element(at: 5) ?? "")
+        }.frame(maxWidth: .infinity)
+    }
+}
+
+struct SessionCodeText_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            SessionCodeText(sessionCode: "000000")
+                .environment(\.colorScheme, .light)
+                .previewDisplayName("Light mode")
+            SessionCodeText(sessionCode: "")
+                .environment(\.colorScheme, .dark)
+                .previewDisplayName("Dark mode")
+                .background(Color.black)
+        }.previewLayout(.sizeThatFits)
+    }
+}

--- a/mamba/mamba/Styling/Components/TextField/SessionCodeTextField.swift
+++ b/mamba/mamba/Styling/Components/TextField/SessionCodeTextField.swift
@@ -30,10 +30,10 @@ struct SessionCodeTextField: View {
                 .background(
                     RoundedRectangle(cornerRadius: 10)
                         .foregroundColor(DefaultStyle.shared.systemGray4)
-                        .frame(minHeight: 45)
+                        .frame(minWidth: 38, minHeight: 45)
                 )
                 .multilineTextAlignment(.center)
-                .frame(minHeight: 45)
+                .frame(minWidth: 38, minHeight: 45)
         }
     }
 }


### PR DESCRIPTION
# iOS Pull Request
- [x] Assigned labels
- [x] Description
- [x] Screenshot
- [ ] Unit tests
- [x] Ticket: https://operation-winter.atlassian.net/browse/MAM-35

# Work done
Introduce new share sheet screen that pops up a second after the none state has been loaded

# Screenshot
![Screen Recording 2020-08-04 at 13 28 34](https://user-images.githubusercontent.com/52150410/89289077-f1c56b00-d656-11ea-95bc-0c1f5a5e9fd1.gif)
