### PR TITLE
MAM-31-30-34: Add ticket screen & voting state

### DIFF
--- a/mamba/mamba.xcodeproj/project.pbxproj
+++ b/mamba/mamba.xcodeproj/project.pbxproj
@@ -26,7 +26,7 @@
 		263ECA5524D29B1E00EEAB1E /* PlanningHostAvailableCardsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263ECA5424D29B1E00EEAB1E /* PlanningHostAvailableCardsView.swift */; };
 		263ECA5A24D29D3000EEAB1E /* PlanningHostAvailableCardsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263ECA5924D29D3000EEAB1E /* PlanningHostAvailableCardsViewModel.swift */; };
 		263ECB0224D3081000EEAB1E /* PlanningSessionStateMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263ECB0124D3081000EEAB1E /* PlanningSessionStateMessage.swift */; };
-		263ECC2424D40CBC00EEAB1E /* JoinSessionCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263ECC2324D40CBB00EEAB1E /* JoinSessionCommand.swift */; };
+		263ECC2424D40CBC00EEAB1E /* JoinSessionMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263ECC2324D40CBB00EEAB1E /* JoinSessionMessage.swift */; };
 		263ECC2624D40DC800EEAB1E /* PlanningCommand.JoinSend+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263ECC2524D40DC800EEAB1E /* PlanningCommand.JoinSend+Extensions.swift */; };
 		263ECC2824D40DDE00EEAB1E /* PlanningCommand.JoinReceive+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263ECC2724D40DDE00EEAB1E /* PlanningCommand.JoinReceive+Extensions.swift */; };
 		263ECC2C24D4131100EEAB1E /* PlanningSessionNetworkHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263ECC2B24D4131100EEAB1E /* PlanningSessionNetworkHandler.swift */; };
@@ -66,6 +66,10 @@
 		26F98A5F24D99646007CA2B8 /* PlanningJoinSessionLandingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F98A5E24D99646007CA2B8 /* PlanningJoinSessionLandingViewModel.swift */; };
 		26F98A6124D996CC007CA2B8 /* PlanningJoinNoneStateHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F98A6024D996CC007CA2B8 /* PlanningJoinNoneStateHeaderView.swift */; };
 		26F98A6324D99764007CA2B8 /* PlanningJoinSessionLandingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F98A6224D99764007CA2B8 /* PlanningJoinSessionLandingService.swift */; };
+		26F98A6824DD45C2007CA2B8 /* PlanningAddTicketView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F98A6724DD45C2007CA2B8 /* PlanningAddTicketView.swift */; };
+		26F98A6A24DD468B007CA2B8 /* PlanningAddTicketViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F98A6924DD468B007CA2B8 /* PlanningAddTicketViewModel.swift */; };
+		26F98A6C24DD485A007CA2B8 /* AddBarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F98A6B24DD485A007CA2B8 /* AddBarButton.swift */; };
+		26F98A6E24DD4B18007CA2B8 /* AddTicketMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F98A6D24DD4B18007CA2B8 /* AddTicketMessage.swift */; };
 		ED36B44D24BCCDD5007FF62E /* PlanningCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED36B44C24BCCDD5007FF62E /* PlanningCommand.swift */; };
 		ED38EABF24AE5C4800564F85 /* Array+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED38EABE24AE5C4800564F85 /* Array+Extensions.swift */; };
 		ED38EACD24AE60A900564F85 /* PlanningHostSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED38EACC24AE60A800564F85 /* PlanningHostSetupView.swift */; };
@@ -124,7 +128,7 @@
 		263ECA5424D29B1E00EEAB1E /* PlanningHostAvailableCardsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanningHostAvailableCardsView.swift; sourceTree = "<group>"; };
 		263ECA5924D29D3000EEAB1E /* PlanningHostAvailableCardsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanningHostAvailableCardsViewModel.swift; sourceTree = "<group>"; };
 		263ECB0124D3081000EEAB1E /* PlanningSessionStateMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanningSessionStateMessage.swift; sourceTree = "<group>"; };
-		263ECC2324D40CBB00EEAB1E /* JoinSessionCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinSessionCommand.swift; sourceTree = "<group>"; };
+		263ECC2324D40CBB00EEAB1E /* JoinSessionMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinSessionMessage.swift; sourceTree = "<group>"; };
 		263ECC2524D40DC800EEAB1E /* PlanningCommand.JoinSend+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlanningCommand.JoinSend+Extensions.swift"; sourceTree = "<group>"; };
 		263ECC2724D40DDE00EEAB1E /* PlanningCommand.JoinReceive+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlanningCommand.JoinReceive+Extensions.swift"; sourceTree = "<group>"; };
 		263ECC2B24D4131100EEAB1E /* PlanningSessionNetworkHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanningSessionNetworkHandler.swift; sourceTree = "<group>"; };
@@ -164,6 +168,10 @@
 		26F98A5E24D99646007CA2B8 /* PlanningJoinSessionLandingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanningJoinSessionLandingViewModel.swift; sourceTree = "<group>"; };
 		26F98A6024D996CC007CA2B8 /* PlanningJoinNoneStateHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanningJoinNoneStateHeaderView.swift; sourceTree = "<group>"; };
 		26F98A6224D99764007CA2B8 /* PlanningJoinSessionLandingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanningJoinSessionLandingService.swift; sourceTree = "<group>"; };
+		26F98A6724DD45C2007CA2B8 /* PlanningAddTicketView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanningAddTicketView.swift; sourceTree = "<group>"; };
+		26F98A6924DD468B007CA2B8 /* PlanningAddTicketViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanningAddTicketViewModel.swift; sourceTree = "<group>"; };
+		26F98A6B24DD485A007CA2B8 /* AddBarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddBarButton.swift; sourceTree = "<group>"; };
+		26F98A6D24DD4B18007CA2B8 /* AddTicketMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTicketMessage.swift; sourceTree = "<group>"; };
 		ED36B44C24BCCDD5007FF62E /* PlanningCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanningCommand.swift; sourceTree = "<group>"; };
 		ED38EABE24AE5C4800564F85 /* Array+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Extensions.swift"; sourceTree = "<group>"; };
 		ED38EACC24AE60A800564F85 /* PlanningHostSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanningHostSetupView.swift; sourceTree = "<group>"; };
@@ -285,6 +293,7 @@
 				263ECA4224D18BE600EEAB1E /* RoundedButton.swift */,
 				263ECA4C24D1943400EEAB1E /* CancelBarButton.swift */,
 				26F98A5624D97ACA007CA2B8 /* DoneBarButton.swift */,
+				26F98A6B24DD485A007CA2B8 /* AddBarButton.swift */,
 			);
 			path = Button;
 			sourceTree = "<group>";
@@ -374,7 +383,8 @@
 				269CA0DB24D93BB2000F42B9 /* PlanningParticipant.swift */,
 				2661E01624BC818600D46119 /* SetupSessionMessage.swift */,
 				263ECB0124D3081000EEAB1E /* PlanningSessionStateMessage.swift */,
-				263ECC2324D40CBB00EEAB1E /* JoinSessionCommand.swift */,
+				263ECC2324D40CBB00EEAB1E /* JoinSessionMessage.swift */,
+				26F98A6D24DD4B18007CA2B8 /* AddTicketMessage.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -550,6 +560,31 @@
 			path = Services;
 			sourceTree = "<group>";
 		};
+		26F98A6424DD456C007CA2B8 /* Add Ticket */ = {
+			isa = PBXGroup;
+			children = (
+				26F98A6524DD45A7007CA2B8 /* Views */,
+				26F98A6624DD45AD007CA2B8 /* ViewModels */,
+			);
+			path = "Add Ticket";
+			sourceTree = "<group>";
+		};
+		26F98A6524DD45A7007CA2B8 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				26F98A6724DD45C2007CA2B8 /* PlanningAddTicketView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		26F98A6624DD45AD007CA2B8 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				26F98A6924DD468B007CA2B8 /* PlanningAddTicketViewModel.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
 		ED01C6EA24BCD2FE00A23727 /* URLCenter */ = {
 			isa = PBXGroup;
 			children = (
@@ -596,6 +631,7 @@
 				26018A2224B49C2300C8B268 /* Session Setup */,
 				263ECA5624D29CF800EEAB1E /* Card Selection */,
 				269CA06624D931C5000F42B9 /* Session Landing */,
+				26F98A6424DD456C007CA2B8 /* Add Ticket */,
 			);
 			path = Host;
 			sourceTree = "<group>";
@@ -828,7 +864,7 @@
 				26F98A5724D97ACA007CA2B8 /* DoneBarButton.swift in Sources */,
 				ED9D447B24AE4BEA00034216 /* LandingItem.swift in Sources */,
 				26772B0224B4ACC4003FB1A4 /* ClearableTextField.swift in Sources */,
-				263ECC2424D40CBC00EEAB1E /* JoinSessionCommand.swift in Sources */,
+				263ECC2424D40CBC00EEAB1E /* JoinSessionMessage.swift in Sources */,
 				269CA0DE24D93E00000F42B9 /* HCardView.swift in Sources */,
 				2661E01D24BC931C00D46119 /* WebSocketHandler.swift in Sources */,
 				26F98A6324D99764007CA2B8 /* PlanningJoinSessionLandingService.swift in Sources */,
@@ -857,16 +893,20 @@
 				26F98A6124D996CC007CA2B8 /* PlanningJoinNoneStateHeaderView.swift in Sources */,
 				ED83E28824C46D1400FCAB27 /* NetworkCloseError.swift in Sources */,
 				269CA06C24D93209000F42B9 /* PlanningHostSessionLandingViewModel.swift in Sources */,
+				26F98A6824DD45C2007CA2B8 /* PlanningAddTicketView.swift in Sources */,
 				263EC96C24D16FBF00EEAB1E /* PlanningCard.swift in Sources */,
 				26772B0824B4B428003FB1A4 /* PlanningColorScheme.swift in Sources */,
 				ED38EACD24AE60A900564F85 /* PlanningHostSetupView.swift in Sources */,
+				26F98A6E24DD4B18007CA2B8 /* AddTicketMessage.swift in Sources */,
 				269CA0E424D94BCC000F42B9 /* PlanningSessionLandingState.swift in Sources */,
+				26F98A6A24DD468B007CA2B8 /* PlanningAddTicketViewModel.swift in Sources */,
 				263ECA5524D29B1E00EEAB1E /* PlanningHostAvailableCardsView.swift in Sources */,
 				263ECC3424D4178D00EEAB1E /* PlanningJoinSetupViewModel.swift in Sources */,
 				263ECC2C24D4131100EEAB1E /* PlanningSessionNetworkHandler.swift in Sources */,
 				26772AFD24B4AA04003FB1A4 /* ClearButton.swift in Sources */,
 				ED9D448824AE54F800034216 /* ContentView.swift in Sources */,
 				269CA06824D931ED000F42B9 /* PlanningHostSessionLandingView.swift in Sources */,
+				26F98A6C24DD485A007CA2B8 /* AddBarButton.swift in Sources */,
 				ED38EABF24AE5C4800564F85 /* Array+Extensions.swift in Sources */,
 				269CA06F24D9332A000F42B9 /* PlanningHostSessionLandingService.swift in Sources */,
 				263ECC2824D40DDE00EEAB1E /* PlanningCommand.JoinReceive+Extensions.swift in Sources */,

--- a/mamba/mamba.xcodeproj/project.pbxproj
+++ b/mamba/mamba.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		269F557B24BC301600EEC682 /* LocalNetworkEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269F557A24BC301600EEC682 /* LocalNetworkEnvironment.swift */; };
 		269F557D24BC302500EEC682 /* DevelopmentNetworkEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269F557C24BC302500EEC682 /* DevelopmentNetworkEnvironment.swift */; };
 		26E11B3624D429FF00C50F43 /* IntegerTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E11B3524D429FF00C50F43 /* IntegerTextField.swift */; };
+		26E2F56424DD5B31008B2B4B /* PlanningJoinVotingCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E2F56324DD5B31008B2B4B /* PlanningJoinVotingCardView.swift */; };
 		26F98A4F24D9613B007CA2B8 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F98A4E24D9613B007CA2B8 /* LoadingView.swift */; };
 		26F98A5124D96A52007CA2B8 /* PlanningHostSessionStartShareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F98A5024D96A52007CA2B8 /* PlanningHostSessionStartShareView.swift */; };
 		26F98A5324D96CAE007CA2B8 /* SessionCodeText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F98A5224D96CAE007CA2B8 /* SessionCodeText.swift */; };
@@ -161,6 +162,7 @@
 		269F557A24BC301600EEC682 /* LocalNetworkEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNetworkEnvironment.swift; sourceTree = "<group>"; };
 		269F557C24BC302500EEC682 /* DevelopmentNetworkEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevelopmentNetworkEnvironment.swift; sourceTree = "<group>"; };
 		26E11B3524D429FF00C50F43 /* IntegerTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegerTextField.swift; sourceTree = "<group>"; };
+		26E2F56324DD5B31008B2B4B /* PlanningJoinVotingCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanningJoinVotingCardView.swift; sourceTree = "<group>"; };
 		26F98A4E24D9613B007CA2B8 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
 		26F98A5024D96A52007CA2B8 /* PlanningHostSessionStartShareView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanningHostSessionStartShareView.swift; sourceTree = "<group>"; };
 		26F98A5224D96CAE007CA2B8 /* SessionCodeText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCodeText.swift; sourceTree = "<group>"; };
@@ -545,6 +547,7 @@
 			children = (
 				26F98A5C24D995A8007CA2B8 /* PlanningJoinSessionLandingView.swift */,
 				26F98A6024D996CC007CA2B8 /* PlanningJoinNoneStateHeaderView.swift */,
+				26E2F56324DD5B31008B2B4B /* PlanningJoinVotingCardView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -911,6 +914,7 @@
 				269F557B24BC301600EEC682 /* LocalNetworkEnvironment.swift in Sources */,
 				26772AFA24B4A66D003FB1A4 /* ClearableTextFieldStyle.swift in Sources */,
 				269F557424BC2D4A00EEC682 /* URLCenter.swift in Sources */,
+				26E2F56424DD5B31008B2B4B /* PlanningJoinVotingCardView.swift in Sources */,
 				26F98A7024DD4E6B007CA2B8 /* PlanningVotingStateTicketCardView.swift in Sources */,
 				ED9D448524AE4DC800034216 /* LandingItemView.swift in Sources */,
 				269F557924BC300600EEC682 /* NetworkEnvironment.swift in Sources */,

--- a/mamba/mamba.xcodeproj/project.pbxproj
+++ b/mamba/mamba.xcodeproj/project.pbxproj
@@ -70,6 +70,8 @@
 		26F98A6A24DD468B007CA2B8 /* PlanningAddTicketViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F98A6924DD468B007CA2B8 /* PlanningAddTicketViewModel.swift */; };
 		26F98A6C24DD485A007CA2B8 /* AddBarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F98A6B24DD485A007CA2B8 /* AddBarButton.swift */; };
 		26F98A6E24DD4B18007CA2B8 /* AddTicketMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F98A6D24DD4B18007CA2B8 /* AddTicketMessage.swift */; };
+		26F98A7024DD4E6B007CA2B8 /* PlanningVotingStateTicketCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F98A6F24DD4E6B007CA2B8 /* PlanningVotingStateTicketCardView.swift */; };
+		26F98A7424DD5163007CA2B8 /* PlanningTicket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F98A7324DD5163007CA2B8 /* PlanningTicket.swift */; };
 		ED36B44D24BCCDD5007FF62E /* PlanningCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED36B44C24BCCDD5007FF62E /* PlanningCommand.swift */; };
 		ED38EABF24AE5C4800564F85 /* Array+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED38EABE24AE5C4800564F85 /* Array+Extensions.swift */; };
 		ED38EACD24AE60A900564F85 /* PlanningHostSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED38EACC24AE60A800564F85 /* PlanningHostSetupView.swift */; };
@@ -172,6 +174,8 @@
 		26F98A6924DD468B007CA2B8 /* PlanningAddTicketViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanningAddTicketViewModel.swift; sourceTree = "<group>"; };
 		26F98A6B24DD485A007CA2B8 /* AddBarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddBarButton.swift; sourceTree = "<group>"; };
 		26F98A6D24DD4B18007CA2B8 /* AddTicketMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTicketMessage.swift; sourceTree = "<group>"; };
+		26F98A6F24DD4E6B007CA2B8 /* PlanningVotingStateTicketCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanningVotingStateTicketCardView.swift; sourceTree = "<group>"; };
+		26F98A7324DD5163007CA2B8 /* PlanningTicket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanningTicket.swift; sourceTree = "<group>"; };
 		ED36B44C24BCCDD5007FF62E /* PlanningCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanningCommand.swift; sourceTree = "<group>"; };
 		ED38EABE24AE5C4800564F85 /* Array+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Extensions.swift"; sourceTree = "<group>"; };
 		ED38EACC24AE60A800564F85 /* PlanningHostSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanningHostSetupView.swift; sourceTree = "<group>"; };
@@ -379,10 +383,11 @@
 		2661E01324BC5FF000D46119 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				26F98A7324DD5163007CA2B8 /* PlanningTicket.swift */,
 				263EC96B24D16FBF00EEAB1E /* PlanningCard.swift */,
 				269CA0DB24D93BB2000F42B9 /* PlanningParticipant.swift */,
-				2661E01624BC818600D46119 /* SetupSessionMessage.swift */,
 				263ECB0124D3081000EEAB1E /* PlanningSessionStateMessage.swift */,
+				2661E01624BC818600D46119 /* SetupSessionMessage.swift */,
 				263ECC2324D40CBB00EEAB1E /* JoinSessionMessage.swift */,
 				26F98A6D24DD4B18007CA2B8 /* AddTicketMessage.swift */,
 			);
@@ -472,8 +477,8 @@
 			children = (
 				269CA06724D931ED000F42B9 /* PlanningHostSessionLandingView.swift */,
 				269CA0DF24D9479A000F42B9 /* PlanningParticipantRowView.swift */,
-				269CA0E124D947EA000F42B9 /* PlanningHostNoneStateCardView.swift */,
 				26F98A5024D96A52007CA2B8 /* PlanningHostSessionStartShareView.swift */,
+				269CA0E124D947EA000F42B9 /* PlanningHostNoneStateCardView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -585,6 +590,22 @@
 			path = ViewModels;
 			sourceTree = "<group>";
 		};
+		26F98A7124DD501B007CA2B8 /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				26F98A7224DD5022007CA2B8 /* Views */,
+			);
+			path = Shared;
+			sourceTree = "<group>";
+		};
+		26F98A7224DD5022007CA2B8 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				26F98A6F24DD4E6B007CA2B8 /* PlanningVotingStateTicketCardView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
 		ED01C6EA24BCD2FE00A23727 /* URLCenter */ = {
 			isa = PBXGroup;
 			children = (
@@ -619,6 +640,7 @@
 		ED38EAC124AE604300564F85 /* Planning */ = {
 			isa = PBXGroup;
 			children = (
+				26F98A7124DD501B007CA2B8 /* Shared */,
 				ED38EAC324AE605E00564F85 /* Join */,
 				ED38EAC224AE605800564F85 /* Host */,
 			);
@@ -858,6 +880,7 @@
 			files = (
 				269CA0E024D9479A000F42B9 /* PlanningParticipantRowView.swift in Sources */,
 				2661E01724BC818600D46119 /* SetupSessionMessage.swift in Sources */,
+				26F98A7424DD5163007CA2B8 /* PlanningTicket.swift in Sources */,
 				ED83E28924C46F3A00FCAB27 /* NetworkError.swift in Sources */,
 				26772AF624B4A4DC003FB1A4 /* PlanningHostSetupViewModel.swift in Sources */,
 				269F557D24BC302500EEC682 /* DevelopmentNetworkEnvironment.swift in Sources */,
@@ -888,6 +911,7 @@
 				269F557B24BC301600EEC682 /* LocalNetworkEnvironment.swift in Sources */,
 				26772AFA24B4A66D003FB1A4 /* ClearableTextFieldStyle.swift in Sources */,
 				269F557424BC2D4A00EEC682 /* URLCenter.swift in Sources */,
+				26F98A7024DD4E6B007CA2B8 /* PlanningVotingStateTicketCardView.swift in Sources */,
 				ED9D448524AE4DC800034216 /* LandingItemView.swift in Sources */,
 				269F557924BC300600EEC682 /* NetworkEnvironment.swift in Sources */,
 				26F98A6124D996CC007CA2B8 /* PlanningJoinNoneStateHeaderView.swift in Sources */,

--- a/mamba/mamba/Networking/Commands/Planning/Models/AddTicketMessage.swift
+++ b/mamba/mamba/Networking/Commands/Planning/Models/AddTicketMessage.swift
@@ -8,12 +8,7 @@
 
 import Foundation
 
-public class AddTicketMessage: Codable {
+public struct AddTicketMessage: Codable {
     let identifier: String
     let description: String
-    
-    public init(identifier: String, description: String) {
-        self.identifier = identifier
-        self.description = description
-    }
 }

--- a/mamba/mamba/Networking/Commands/Planning/Models/AddTicketMessage.swift
+++ b/mamba/mamba/Networking/Commands/Planning/Models/AddTicketMessage.swift
@@ -1,0 +1,19 @@
+//
+//  AddTicketMessage.swift
+//  mamba
+//
+//  Created by Armand Kamffer on 2020/08/07.
+//  Copyright © 2020 Armand Kamffer. All rights reserved.
+//
+
+import Foundation
+
+public class AddTicketMessage: Codable {
+    let identifier: String
+    let description: String
+    
+    public init(identifier: String, description: String) {
+        self.identifier = identifier
+        self.description = description
+    }
+}

--- a/mamba/mamba/Networking/Commands/Planning/Models/JoinSessionMessage.swift
+++ b/mamba/mamba/Networking/Commands/Planning/Models/JoinSessionMessage.swift
@@ -1,5 +1,5 @@
 //
-//  JoinSessionCommand.swift
+//  JoinSessionMessage.swift
 //  mamba
 //
 //  Created by Armand Kamffer on 2020/07/31.

--- a/mamba/mamba/Networking/Commands/Planning/Models/PlanningSessionStateMessage.swift
+++ b/mamba/mamba/Networking/Commands/Planning/Models/PlanningSessionStateMessage.swift
@@ -13,4 +13,5 @@ public struct PlanningSessionStateMessage: Codable {
     let sessionName: String
     let availableCards: [PlanningCard]
     let participants: [PlanningParticipant]
+    let ticket: PlanningTicket?
 }

--- a/mamba/mamba/Networking/Commands/Planning/Models/PlanningTicket.swift
+++ b/mamba/mamba/Networking/Commands/Planning/Models/PlanningTicket.swift
@@ -1,0 +1,19 @@
+//
+//  PlanningTicket.swift
+//  mamba
+//
+//  Created by Armand Kamffer on 2020/08/07.
+//  Copyright © 2020 Armand Kamffer. All rights reserved.
+//
+
+import Foundation
+
+class PlanningTicket: Codable {
+    private(set) var identifier: String
+    private(set) var description: String
+    
+    init(identifier: String, description: String) {
+        self.identifier = identifier
+        self.description = description
+    }
+}

--- a/mamba/mamba/Networking/Commands/Planning/Models/SetupSessionMessage.swift
+++ b/mamba/mamba/Networking/Commands/Planning/Models/SetupSessionMessage.swift
@@ -1,5 +1,5 @@
 //
-//  SetupSessionCommand.swift
+//  StartSessionMessage.swift
 //  mamba
 //
 //  Created by Armand Kamffer on 2020/07/13.

--- a/mamba/mamba/Networking/Commands/Planning/PlanningCommand.HostReceive+Extensions.swift
+++ b/mamba/mamba/Networking/Commands/Planning/PlanningCommand.HostReceive+Extensions.swift
@@ -35,18 +35,6 @@ public extension PlanningCommands.HostReceive {
         }
     }
     
-    func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(self.rawValue, forKey: .type)
-        
-        switch self {
-        case .noneState(let message): try container.encode(message, forKey: .message)
-        case .votingState(let message): try container.encode(message, forKey: .message)
-        case .finishedState(let message): try container.encode(message, forKey: .message)
-        default: try container.encodeNil(forKey: .message)
-        }
-    }
-    
     var rawValue: String {
         switch self {
         case .noneState: return PlanningCommands.HostKey.noneState.rawValue

--- a/mamba/mamba/Networking/Commands/Planning/PlanningCommand.HostSend+Extensions.swift
+++ b/mamba/mamba/Networking/Commands/Planning/PlanningCommand.HostSend+Extensions.swift
@@ -14,37 +14,13 @@ public extension PlanningCommands.HostSend {
         case message
     }
     
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let type = try container.decode(String.self, forKey: .type)
-        
-        switch type {
-        case PlanningCommands.HostKey.addTicket.rawValue:
-            self = .addTicket
-        case PlanningCommands.HostKey.endSession.rawValue:
-            self = .endSession
-        case PlanningCommands.HostKey.finishVoting.rawValue:
-            self = .finishVoting
-        case PlanningCommands.HostKey.reconnect.rawValue:
-            self = .reconnect
-        case PlanningCommands.HostKey.removeParticipant.rawValue:
-            self = .removeParticipant
-        case PlanningCommands.HostKey.skipVote.rawValue:
-            self = .skipVote
-        case PlanningCommands.HostKey.startSession.rawValue:
-            let model = try container.decode(StartSessionMessage.self, forKey: .message)
-            self = .startSession(model)
-        default:
-            throw DecodingError.keyNotFound(CodingKeys.message, DecodingError.Context(codingPath: [], debugDescription: "Invalid key: \(type)"))
-        }
-    }
-    
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(self.rawValue, forKey: .type)
         
         switch self {
         case .startSession(let message): try container.encode(message, forKey: .message)
+        case .addTicket(let message): try container.encode(message, forKey: .message)
         default: try container.encodeNil(forKey: .message)
         }
     }

--- a/mamba/mamba/Networking/Commands/Planning/PlanningCommand.JoinReceive+Extensions.swift
+++ b/mamba/mamba/Networking/Commands/Planning/PlanningCommand.JoinReceive+Extensions.swift
@@ -41,18 +41,6 @@ public extension PlanningCommands.JoinReceive {
         }
     }
     
-    func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(self.rawValue, forKey: .type)
-        
-        switch self {
-        case .noneState(let message): try container.encode(message, forKey: .message)
-        case .votingState(let message): try container.encode(message, forKey: .message)
-        case .finishedState(let message): try container.encode(message, forKey: .message)
-        default: try container.encodeNil(forKey: .message)
-        }
-    }
-    
     var rawValue: String {
         switch self {
         case .noneState(_): return PlanningCommands.JoinKey.noneState.rawValue

--- a/mamba/mamba/Networking/Commands/Planning/PlanningCommand.JoinSend+Extensions.swift
+++ b/mamba/mamba/Networking/Commands/Planning/PlanningCommand.JoinSend+Extensions.swift
@@ -14,25 +14,6 @@ public extension PlanningCommands.JoinSend {
         case message
     }
     
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let type = try container.decode(String.self, forKey: .type)
-        
-        switch type {
-        case PlanningCommands.JoinKey.joinSession.rawValue:
-            let model = try container.decode(JoinSessionMessage.self, forKey: .message)
-            self = .joinSession(model)
-        case PlanningCommands.JoinKey.vote.rawValue:
-            self = .vote
-        case PlanningCommands.JoinKey.leaveSession.rawValue:
-            self = .leaveSession
-        case PlanningCommands.JoinKey.reconnect.rawValue:
-            self = .reconnect
-        default:
-            throw DecodingError.keyNotFound(CodingKeys.message, DecodingError.Context(codingPath: [], debugDescription: "Invalid key: \(type)"))
-        }
-    }
-    
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(self.rawValue, forKey: .type)

--- a/mamba/mamba/Networking/Commands/Planning/PlanningCommand.swift
+++ b/mamba/mamba/Networking/Commands/Planning/PlanningCommand.swift
@@ -26,9 +26,9 @@ public enum PlanningCommands {
         case invalidCommand = "INVALID_COMMAND"
     }
 
-    public enum HostSend: Codable {
+    public enum HostSend: Encodable {
         case startSession(StartSessionMessage)
-        case addTicket
+        case addTicket(AddTicketMessage)
         case skipVote
         case removeParticipant
         case endSession
@@ -36,7 +36,7 @@ public enum PlanningCommands {
         case reconnect
     }
     
-    public enum HostReceive: Codable {
+    public enum HostReceive: Decodable {
         case noneState(PlanningSessionStateMessage)
         case votingState(PlanningSessionStateMessage)
         case finishedState(PlanningSessionStateMessage)
@@ -60,14 +60,14 @@ public enum PlanningCommands {
         case endSession = "END_SESSION"
     }
     
-    public enum JoinSend: Codable {
+    public enum JoinSend: Encodable {
         case joinSession(JoinSessionMessage)
         case vote
         case leaveSession
         case reconnect
     }
     
-    public enum JoinReceive: Codable {
+    public enum JoinReceive: Decodable {
         case noneState(PlanningSessionStateMessage)
         case votingState(PlanningSessionStateMessage)
         case finishedState(PlanningSessionStateMessage)

--- a/mamba/mamba/Networking/PlanningSessionNetworkHandler.swift
+++ b/mamba/mamba/Networking/PlanningSessionNetworkHandler.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Combine
 
-public class PlanningSessionNetworkHandler<Send: Codable, Receive: Codable> {
+public class PlanningSessionNetworkHandler<Send: Encodable, Receive: Decodable> {
     private var webSocket: WebSocketHandler?
     
     public func startSession(webSocketURL: URL) -> AnyPublisher<Result<Receive, NetworkError>, NetworkCloseError> {
@@ -37,7 +37,7 @@ public class PlanningSessionNetworkHandler<Send: Codable, Receive: Codable> {
         }
     }
     
-    private func createWebSocketPublisher<Command>(_ webSocketSubject: PassthroughSubject<URLSessionWebSocketTask.Message, NetworkCloseError>) -> AnyPublisher<Result<Command, NetworkError>, NetworkCloseError> where Command : Codable {
+    private func createWebSocketPublisher<Command: Decodable>(_ webSocketSubject: PassthroughSubject<URLSessionWebSocketTask.Message, NetworkCloseError>) -> AnyPublisher<Result<Command, NetworkError>, NetworkCloseError> {
         return webSocketSubject
             .compactMap { self.parseMessage($0) }
             .map { self.decodeCommand($0) }
@@ -52,7 +52,7 @@ public class PlanningSessionNetworkHandler<Send: Codable, Receive: Codable> {
         }
     }
     
-    private func decodeCommand<Command>(_ data: Data) -> Result<Command, NetworkError> where Command : Codable {
+    private func decodeCommand<Command: Decodable>(_ data: Data) -> Result<Command, NetworkError> {
         do {
             //TODO: Use os_log
             let jsonString = String(decoding: data, as: UTF8.self)

--- a/mamba/mamba/Planning/Host/Add Ticket/ViewModels/PlanningAddTicketViewModel.swift
+++ b/mamba/mamba/Planning/Host/Add Ticket/ViewModels/PlanningAddTicketViewModel.swift
@@ -1,0 +1,18 @@
+//
+//  PlanningAddTicketViewModel.swift
+//  mamba
+//
+//  Created by Armand Kamffer on 2020/08/07.
+//  Copyright © 2020 Armand Kamffer. All rights reserved.
+//
+
+import Foundation
+
+class PlanningAddTicketViewModel: ObservableObject {
+    @Published var ticketIdentifier: String = ""
+    @Published var ticketDescription: String = ""
+    
+    var isInputValid: Bool {
+        !ticketIdentifier.isEmpty && !ticketDescription.isEmpty
+    }
+}

--- a/mamba/mamba/Planning/Host/Add Ticket/Views/PlanningAddTicketView.swift
+++ b/mamba/mamba/Planning/Host/Add Ticket/Views/PlanningAddTicketView.swift
@@ -1,0 +1,53 @@
+//
+//  AddTicketView.swift
+//  mamba
+//
+//  Created by Armand Kamffer on 2020/08/07.
+//  Copyright © 2020 Armand Kamffer. All rights reserved.
+//
+
+import SwiftUI
+
+struct PlanningAddTicketView: View {
+    @ObservedObject private var viewModel = PlanningAddTicketViewModel()
+    @Binding var showSheet: Bool
+    
+    let doneTapped: (_ identifier: String, _ description: String) -> Void
+    
+    var body: some View {
+        NavigationView {
+            VStack {
+                VCardView {
+                    Text("Ticket details")
+                        .foregroundColor(.accentColor)
+                        .font(.system(size: 16))
+                        .fontWeight(.light)
+                        .padding(leading: 20, top: 20, trailing: 20)
+                    
+                    ClearableTextField(text: self.$viewModel.ticketIdentifier,
+                                       placeholder: "PLANNING_HOST_ADD_TICKET_IDENTIFIER_PLACEHOLDER")
+                        .padding(leading: 20, top: 10, trailing: 20)
+                    
+                    ClearableTextField(text: self.$viewModel.ticketDescription,
+                                       placeholder: "PLANNING_HOST_ADD_TICKET_DESCRIPTION_PLACEHOLDER")
+                        .padding(leading: 20, top: 10, bottom: 20, trailing: 20)
+                }
+                
+                Spacer()
+            }
+            .navigationBarTitle("PLANNING_HOST_LANDING_ADD_TICKET_MODAL_TITLE", displayMode: .inline)
+            .navigationBarItems(leading: CancelBarButton { self.showSheet.toggle() },
+                                trailing: AddBarButton {
+                                    self.doneTapped(self.viewModel.ticketIdentifier, self.viewModel.ticketDescription)
+                                    self.showSheet.toggle()
+                                }.disabled(!self.viewModel.isInputValid))
+        }
+        .navigationViewStyle(StackNavigationViewStyle())
+    }
+}
+
+struct PlanningAddTicketView_Previews: PreviewProvider {
+    static var previews: some View {
+        PlanningAddTicketView(showSheet: .constant(true), doneTapped: {_,_ in })
+    }
+}

--- a/mamba/mamba/Planning/Host/Session Landing/ViewModels/PlanningHostSessionLandingViewModel.swift
+++ b/mamba/mamba/Planning/Host/Session Landing/ViewModels/PlanningHostSessionLandingViewModel.swift
@@ -18,6 +18,7 @@ class PlanningHostSessionLandingViewModel: ObservableObject {
     @Published var sessionName: String
     @Published var participants = [PlanningParticipant]()
     @Published var showInitialShareModal: Bool = false
+    @Published var ticket: PlanningTicket?
     
     init(sessionName: String, availableCards: [PlanningCard]) {
         self.service = PlanningHostSessionLandingService()
@@ -88,5 +89,6 @@ class PlanningHostSessionLandingViewModel: ObservableObject {
         self.participants = message.participants
         self.sessionCode = message.sessionCode
         self.sessionName = message.sessionName
+        self.ticket = message.ticket
     }
 }

--- a/mamba/mamba/Planning/Host/Session Landing/ViewModels/PlanningHostSessionLandingViewModel.swift
+++ b/mamba/mamba/Planning/Host/Session Landing/ViewModels/PlanningHostSessionLandingViewModel.swift
@@ -32,6 +32,12 @@ class PlanningHostSessionLandingViewModel: ObservableObject {
         //TODO: MAM-28 Exception handling
     }
     
+    func sendAddTicketCommand(identifier: String, description: String) {
+        let commandMessage = AddTicketMessage(identifier: identifier, description: description)
+        try? service.sendCommand(.addTicket(commandMessage))
+        //TODO: MAM-28 Exception handling
+    }
+    
     private func startSession() {
         guard cancellable == nil else { return }
         cancellable = service.startSession()

--- a/mamba/mamba/Planning/Host/Session Landing/Views/PlanningHostSessionLandingView.swift
+++ b/mamba/mamba/Planning/Host/Session Landing/Views/PlanningHostSessionLandingView.swift
@@ -53,7 +53,11 @@ struct PlanningHostSessionLandingView: View {
     }
     
     private func addTicket() {
-        //TODO: MAM-31
+        let addTicketView = PlanningAddTicketView(showSheet: $navigation.showSheet) { identifier, description in
+            self.viewModel.sendAddTicketCommand(identifier: identifier, description: description)
+        }
+        navigation.modal(AnyView(addTicketView))
+        navigation.showSheet = true
     }
     
     private func showShareModal() {

--- a/mamba/mamba/Planning/Host/Session Landing/Views/PlanningHostSessionLandingView.swift
+++ b/mamba/mamba/Planning/Host/Session Landing/Views/PlanningHostSessionLandingView.swift
@@ -53,7 +53,7 @@ struct PlanningHostSessionLandingView: View {
                         PlanningParticipantRowView(participant: participant)
                     }
                 }
-                .padding(leading: 15, top: 5, bottom: 20, trailing: 15)
+                .padding(leading: 15, top: 20, bottom: 20, trailing: 15)
             }
         }
     }

--- a/mamba/mamba/Planning/Host/Session Landing/Views/PlanningHostSessionLandingView.swift
+++ b/mamba/mamba/Planning/Host/Session Landing/Views/PlanningHostSessionLandingView.swift
@@ -42,6 +42,12 @@ struct PlanningHostSessionLandingView: View {
                     })
                 }
                 
+                if self.viewModel.state == .voting {
+                    PlanningVotingStateTicketCardView(title: self.viewModel.sessionName,
+                                                      ticketIdentifier: self.viewModel.ticket?.identifier,
+                                                      ticketDescription: self.viewModel.ticket?.description)
+                }
+                
                 VStack(alignment: .center, spacing: 10) {
                     ForEach(self.viewModel.participants) { participant in
                         PlanningParticipantRowView(participant: participant)

--- a/mamba/mamba/Planning/Join/Session Landing/ViewModels/PlanningJoinSessionLandingViewModel.swift
+++ b/mamba/mamba/Planning/Join/Session Landing/ViewModels/PlanningJoinSessionLandingViewModel.swift
@@ -14,9 +14,12 @@ class PlanningJoinSessionLandingViewModel: ObservableObject {
     private var sessionCode: String
     private var participantName: String
     private var cancellable: AnyCancellable?
+    private(set) var availableCards: [PlanningCard] = []
     @Published var state: PlanningSessionLandingState = .loading
     @Published var sessionName: String = ""
     @Published var participants = [PlanningParticipant]()
+    @Published var ticket: PlanningTicket?
+    @Published var selectedCard: PlanningCard?
     
     init(sessionCode: String, participantName: String) {
         self.service = PlanningJoinSessionLandingService()
@@ -83,5 +86,7 @@ class PlanningJoinSessionLandingViewModel: ObservableObject {
         self.participants = message.participants
         self.sessionCode = message.sessionCode
         self.sessionName = message.sessionName
+        self.ticket = message.ticket
+        self.availableCards = message.availableCards
     }
 }

--- a/mamba/mamba/Planning/Join/Session Landing/Views/PlanningJoinSessionLandingView.swift
+++ b/mamba/mamba/Planning/Join/Session Landing/Views/PlanningJoinSessionLandingView.swift
@@ -35,12 +35,20 @@ struct PlanningJoinSessionLandingView: View {
                     PlanningJoinNoneStateHeaderView(title: self.viewModel.sessionName)
                 }
                 
+                if self.viewModel.state == .voting {
+                    PlanningVotingStateTicketCardView(title: self.viewModel.sessionName,
+                                                      ticketIdentifier: self.viewModel.ticket?.identifier,
+                                                      ticketDescription: self.viewModel.ticket?.description)
+                    
+                    PlanningJoinVotingCardView(selectedCard: self.$viewModel.selectedCard, availableCards: self.viewModel.availableCards)
+                }
+                
                 VStack(alignment: .center, spacing: 10) {
                     ForEach(self.viewModel.participants) { participant in
                         PlanningParticipantRowView(participant: participant)
                     }
                 }
-                .padding(leading: 15, top: 5, bottom: 20, trailing: 15)
+                .padding(leading: 15, top: 20, bottom: 20, trailing: 15)
             }
         }
     }

--- a/mamba/mamba/Planning/Join/Session Landing/Views/PlanningJoinVotingCardView.swift
+++ b/mamba/mamba/Planning/Join/Session Landing/Views/PlanningJoinVotingCardView.swift
@@ -1,0 +1,63 @@
+//
+//  PlanningJoinVotingCardView.swift
+//  mamba
+//
+//  Created by Armand Kamffer on 2020/08/07.
+//  Copyright © 2020 Armand Kamffer. All rights reserved.
+//
+
+import SwiftUI
+
+struct PlanningJoinVotingCardView: View {
+    @Binding var selectedCard: PlanningCard?
+    let availableCards: [PlanningCard]
+    
+    private var chunkedCards: [[PlanningCard]] {
+        availableCards.chunked(into: 3)
+    }
+    
+    var body: some View {
+        VCardView {
+            VStack(alignment: .center, spacing: 20) {
+                ForEach(0 ..< self.chunkedCards.count) { index in
+                    HStack(alignment: .center, spacing: 20) {
+                        ForEach(self.chunkedCards[index], id: \.rawValue) { availableCard in
+                            self.storyPointCard(card: availableCard)
+                                .onTapGesture {
+                                    self.selectedCard = availableCard
+                                }
+                        }
+                    }
+                }
+            }
+            .padding(leading: 20, top: 20, bottom: 20, trailing: 20)
+        }
+    }
+    
+    private func storyPointCard(card: PlanningCard) -> AnyView {
+        if self.selectedCard == card {
+            return AnyView(StoryPointCard(card: card)
+                    .overlay(RoundedRectangle(cornerRadius: 5)
+                            .stroke(DefaultStyle.shared.colorScheme.accent(), lineWidth: 4))
+            )
+        }
+        return AnyView(StoryPointCard(card: card))
+    }
+}
+
+struct PlanningJoinVotingCardView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            PlanningJoinVotingCardView(selectedCard: .constant(.one), availableCards: PlanningCard.allCases)
+                .environment(\.colorScheme, .light)
+                .previewDisplayName("Light mode")
+                .padding()
+            
+            PlanningJoinVotingCardView(selectedCard: .constant(nil), availableCards: PlanningCard.allCases)
+                .environment(\.colorScheme, .dark)
+                .previewDisplayName("Dark mode")
+                .padding()
+                .background(Color.black)
+        }.previewLayout(.sizeThatFits)
+    }
+}

--- a/mamba/mamba/Planning/Shared/Views/PlanningVotingStateTicketCardView.swift
+++ b/mamba/mamba/Planning/Shared/Views/PlanningVotingStateTicketCardView.swift
@@ -1,0 +1,72 @@
+//
+//  PlanningHostVotingStateCardView.swift
+//  mamba
+//
+//  Created by Armand Kamffer on 2020/08/07.
+//  Copyright © 2020 Armand Kamffer. All rights reserved.
+//
+
+import SwiftUI
+
+struct PlanningVotingStateTicketCardView: View {
+    let title: String
+    let ticketIdentifier: String?
+    let ticketDescription: String?
+    
+    var body: some View {
+        let identifier = self.ticketIdentifier ?? NSLocalizedString("PLANNING_TICKET_NO_IDENTIFIER_DESCRIPTION", comment: "No identifier")
+        let description = self.ticketDescription ?? NSLocalizedString("PLANNING_TICKET_NO_DESCRIPTION_DESCRIPTION", comment: "No description")
+        
+        return VCardView {
+            Text(self.title)
+                .font(.system(size: 20))
+                .foregroundColor(.accentColor)
+                .padding(leading: 20, top: 20, trailing: 20)
+                .frame(minWidth: 0, maxWidth: .infinity)
+            
+            Text("PLANNING_TICKET_IDENTIFIER_TITLE")
+                .font(.system(size: 16))
+                .foregroundColor(.accentColor)
+                .fontWeight(.light)
+                .multilineTextAlignment(.center)
+                .padding(leading: 20, top: 15, trailing: 20)
+            
+            Text(identifier)
+                .font(.system(size: 14))
+                .fontWeight(.light)
+                .multilineTextAlignment(.center)
+                .padding(leading: 20, top: 5, trailing: 20)
+            
+            Text("PLANNING_TICKET_DESCRIPTION_TITLE")
+                .font(.system(size: 16))
+                .foregroundColor(.accentColor)
+                .fontWeight(.light)
+                .multilineTextAlignment(.center)
+                .padding(leading: 20, top: 15, trailing: 20)
+            
+            Text(description)
+                .font(.system(size: 14))
+                .fontWeight(.light)
+                .multilineTextAlignment(.center)
+                .padding(leading: 20, top: 5, bottom: 20, trailing: 20)
+        }
+    }
+}
+
+struct PlanningHostVotingStateCardView_Previews: PreviewProvider {
+    static var previews: some View {
+        
+        Group {
+            PlanningVotingStateTicketCardView(title: "Planning 1", ticketIdentifier: "MAM-29", ticketDescription: "Test x and y")
+                .environment(\.colorScheme, .light)
+                .previewDisplayName("Light mode")
+                .padding()
+            
+            PlanningVotingStateTicketCardView(title: "Planning 1", ticketIdentifier: nil, ticketDescription: nil)
+                .environment(\.colorScheme, .dark)
+                .previewDisplayName("Dark mode")
+                .padding()
+                .background(Color.black)
+        }.previewLayout(.sizeThatFits)
+    }
+}

--- a/mamba/mamba/Resources/Localizable.strings
+++ b/mamba/mamba/Resources/Localizable.strings
@@ -4,6 +4,7 @@
 "SOME" = "Some";
 "NONE" = "None";
 "DONE" = "Done";
+"ADD" = "Add";
 
 // MARK: - Landing screen
 "LANDING_PLANNING_HOST" = "HOST PLANNING";
@@ -23,6 +24,9 @@
 "PLANNING_HOST_LANDING_CONNECTING_TITLE" = "Starting session...";
 "PLANNING_HOST_LANDING_SESSION_SHARE_MODAL_TITLE" = "Share session";
 "PLANNING_HOST_LANDING_SESSION_SHARE_MODAL_CODE_TITLE" = "Session Code";
+"PLANNING_HOST_LANDING_ADD_TICKET_MODAL_TITLE" = "New ticket";
+"PLANNING_HOST_ADD_TICKET_IDENTIFIER_PLACEHOLDER" = "Enter ticket identifier...";
+"PLANNING_HOST_ADD_TICKET_DESCRIPTION_PLACEHOLDER" = "Enter ticket description...";
 
 // MARK: - Planning join
 "PLANNING_JOIN_TITLE" = "Join planning";

--- a/mamba/mamba/Resources/Localizable.strings
+++ b/mamba/mamba/Resources/Localizable.strings
@@ -36,3 +36,10 @@
 "PLANNING_JOIN_SETUP_JOIN_SESSION_BUTTON_TITLE" = "JOIN SESSION";
 "PLANNING_JOIN_LANDING_NONE_STATE_DESCRIPTION" = "This is a safe space.\nWait for a ticket to be added.";
 "PLANNING_JOIN_LANDING_CONNECTING_TITLE" = "Joining session...";
+
+
+// MARK: Planning common
+"PLANNING_TICKET_IDENTIFIER_TITLE" = "Ticket identifier";
+"PLANNING_TICKET_DESCRIPTION_TITLE" = "Ticket description";
+"PLANNING_TICKET_NO_IDENTIFIER_DESCRIPTION" = "No ticket identifier provided.";
+"PLANNING_TICKET_NO_DESCRIPTION_DESCRIPTION" = "No ticket description provided.";

--- a/mamba/mamba/Styling/Components/Button/AddBarButton.swift
+++ b/mamba/mamba/Styling/Components/Button/AddBarButton.swift
@@ -1,0 +1,38 @@
+//
+//  AddBarButton.swift
+//  mamba
+//
+//  Created by Armand Kamffer on 2020/08/07.
+//  Copyright © 2020 Armand Kamffer. All rights reserved.
+//
+
+import SwiftUI
+
+struct AddBarButton: View {
+    let action: () -> Void
+    
+    var body: some View {
+        Button(action: {
+            self.action()
+        }) {
+            Text("ADD")
+        }
+    }
+}
+
+struct AddBarButton_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            AddBarButton {}
+                .environment(\.colorScheme, .light)
+                .previewDisplayName("Light mode")
+                .padding()
+            
+            AddBarButton {}
+                .environment(\.colorScheme, .dark)
+                .previewDisplayName("Dark mode")
+                .padding()
+                .background(Color.black)
+        }.previewLayout(.sizeThatFits)
+    }
+}

--- a/mamba/mamba/Styling/Components/Card/VCardView.swift
+++ b/mamba/mamba/Styling/Components/Card/VCardView.swift
@@ -21,7 +21,7 @@ struct VCardView<Content: View>: View {
         }
         .background(DefaultStyle.shared.systemGray5)
         .cornerRadius(10)
-        .padding(15)
+        .padding(leading: 15, top: 15, trailing: 15)
     }
 }
 


### PR DESCRIPTION
# iOS Pull Request
- [x] Assigned labels
- [ ] Description
- [x] Screenshot
- [ ] Unit tests
- [x] Ticket: https://operation-winter.atlassian.net/browse/MAM-31 & https://operation-winter.atlassian.net/browse/MAM-30 & https://operation-winter.atlassian.net/browse/MAM-34

# Work done
Add ability to add a new ticket from the host. Added that the views for both Join and Host change into the Voting state.

# Screenshot
![Screen Recording 2020-08-07 at 12 23 37](https://user-images.githubusercontent.com/52150410/89636855-8fb07400-d8a9-11ea-89e4-0e8041c44d2d.gif)
