### PR TITLE
MAM-63&64&65: Send remove, skip, and finish commands

### DIFF
--- a/mamba/mamba.xcodeproj/project.pbxproj
+++ b/mamba/mamba.xcodeproj/project.pbxproj
@@ -1351,7 +1351,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.2.0;
+				MARKETING_VERSION = 0.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = za.co.armandkamffer.mamba;
 				PRODUCT_NAME = Mamba;
 				SWIFT_VERSION = 5.0;
@@ -1372,7 +1372,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.2.0;
+				MARKETING_VERSION = 0.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = za.co.armandkamffer.mamba;
 				PRODUCT_NAME = Mamba;
 				SWIFT_VERSION = 5.0;

--- a/mamba/mamba.xcodeproj/project.pbxproj
+++ b/mamba/mamba.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		263ECC2824D40DDE00EEAB1E /* PlanningCommands.JoinReceive+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263ECC2724D40DDE00EEAB1E /* PlanningCommands.JoinReceive+Extensions.swift */; };
 		263ECC2C24D4131100EEAB1E /* PlanningSessionNetworkHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263ECC2B24D4131100EEAB1E /* PlanningSessionNetworkHandler.swift */; };
 		263ECC3424D4178D00EEAB1E /* PlanningJoinSetupViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263ECC3324D4178D00EEAB1E /* PlanningJoinSetupViewModel.swift */; };
+		26467A2124EBB27D008A36AD /* PlanningSkipVoteMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26467A2024EBB27D008A36AD /* PlanningSkipVoteMessage.swift */; };
+		26467A2324EBB2D1008A36AD /* PlanningRemoveParticipantMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26467A2224EBB2D1008A36AD /* PlanningRemoveParticipantMessage.swift */; };
 		2661E01224BC5F0400D46119 /* PlanningCommands.HostSend+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2661E01124BC5F0400D46119 /* PlanningCommands.HostSend+Extensions.swift */; };
 		2661E01724BC818600D46119 /* PlanningStartSessionMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2661E01624BC818600D46119 /* PlanningStartSessionMessage.swift */; };
 		2661E01924BC81CB00D46119 /* PlanningCommands.HostReceive+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2661E01824BC81CB00D46119 /* PlanningCommands.HostReceive+Extensions.swift */; };
@@ -174,6 +176,8 @@
 		263ECC2724D40DDE00EEAB1E /* PlanningCommands.JoinReceive+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlanningCommands.JoinReceive+Extensions.swift"; sourceTree = "<group>"; };
 		263ECC2B24D4131100EEAB1E /* PlanningSessionNetworkHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanningSessionNetworkHandler.swift; sourceTree = "<group>"; };
 		263ECC3324D4178D00EEAB1E /* PlanningJoinSetupViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanningJoinSetupViewModel.swift; sourceTree = "<group>"; };
+		26467A2024EBB27D008A36AD /* PlanningSkipVoteMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanningSkipVoteMessage.swift; sourceTree = "<group>"; };
+		26467A2224EBB2D1008A36AD /* PlanningRemoveParticipantMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanningRemoveParticipantMessage.swift; sourceTree = "<group>"; };
 		2661E01124BC5F0400D46119 /* PlanningCommands.HostSend+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlanningCommands.HostSend+Extensions.swift"; sourceTree = "<group>"; };
 		2661E01624BC818600D46119 /* PlanningStartSessionMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanningStartSessionMessage.swift; sourceTree = "<group>"; };
 		2661E01824BC81CB00D46119 /* PlanningCommands.HostReceive+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlanningCommands.HostReceive+Extensions.swift"; sourceTree = "<group>"; };
@@ -610,6 +614,8 @@
 				26F98A6D24DD4B18007CA2B8 /* PlanningAddTicketMessage.swift */,
 				26E2F56A24DD72CF008B2B4B /* PlanningInvalidCommandMessage.swift */,
 				26E2F85224E50E02008B2B4B /* PlanningVoteMessage.swift */,
+				26467A2024EBB27D008A36AD /* PlanningSkipVoteMessage.swift */,
+				26467A2224EBB2D1008A36AD /* PlanningRemoveParticipantMessage.swift */,
 			);
 			path = Messages;
 			sourceTree = "<group>";
@@ -1107,6 +1113,7 @@
 				26F98A5D24D995A8007CA2B8 /* PlanningJoinSessionLandingView.swift in Sources */,
 				263ECA4D24D1943400EEAB1E /* CancelBarButton.swift in Sources */,
 				269CA06524D831D1000F42B9 /* SessionCodeTextField.swift in Sources */,
+				26467A2324EBB2D1008A36AD /* PlanningRemoveParticipantMessage.swift in Sources */,
 				269F557B24BC301600EEC682 /* LocalNetworkEnvironment.swift in Sources */,
 				26772AFA24B4A66D003FB1A4 /* ClearableTextFieldStyle.swift in Sources */,
 				269F557424BC2D4A00EEC682 /* URLCenter.swift in Sources */,
@@ -1145,6 +1152,7 @@
 				263ECA4B24D1931100EEAB1E /* View+Extensions.swift in Sources */,
 				263ECC2624D40DC800EEAB1E /* PlanningCommands.JoinSend+Extensions.swift in Sources */,
 				261E1ED324A48AB600937D89 /* AppDelegate.swift in Sources */,
+				26467A2124EBB27D008A36AD /* PlanningSkipVoteMessage.swift in Sources */,
 				263ECA5A24D29D3000EEAB1E /* PlanningHostAvailableCardsViewModel.swift in Sources */,
 				261E1ED524A48AB700937D89 /* SceneDelegate.swift in Sources */,
 				26F98A4F24D9613B007CA2B8 /* LoadingView.swift in Sources */,

--- a/mamba/mamba/Networking/Commands/Planning/Models/Messages/PlanningRemoveParticipantMessage.swift
+++ b/mamba/mamba/Networking/Commands/Planning/Models/Messages/PlanningRemoveParticipantMessage.swift
@@ -1,0 +1,13 @@
+//
+//  PlanningRemoveParticipantMessage.swift
+//  mamba
+//
+//  Created by Armand Kamffer on 2020/08/18.
+//  Copyright © 2020 Armand Kamffer. All rights reserved.
+//
+
+import Foundation
+
+public struct PlanningRemoveParticipantMessage: Codable {
+    public let participantId: String
+}

--- a/mamba/mamba/Networking/Commands/Planning/Models/Messages/PlanningSkipVoteMessage.swift
+++ b/mamba/mamba/Networking/Commands/Planning/Models/Messages/PlanningSkipVoteMessage.swift
@@ -1,0 +1,13 @@
+//
+//  PlanningSkipVoteMessage.swift
+//  mamba
+//
+//  Created by Armand Kamffer on 2020/08/18.
+//  Copyright © 2020 Armand Kamffer. All rights reserved.
+//
+
+import Foundation
+
+public struct PlanningSkipVoteMessage: Codable {
+    public let participantId: String
+}

--- a/mamba/mamba/Networking/Commands/Planning/Models/Messages/PlanningVoteMessage.swift
+++ b/mamba/mamba/Networking/Commands/Planning/Models/Messages/PlanningVoteMessage.swift
@@ -9,6 +9,6 @@
 import Foundation
 
 public struct PlanningVoteMessage: Codable {
-    let ticketId: String
-    let selectedCard: PlanningCard
+    public let ticketId: String
+    public let selectedCard: PlanningCard
 }

--- a/mamba/mamba/Networking/Commands/Planning/Models/PlanningParticipant.swift
+++ b/mamba/mamba/Networking/Commands/Planning/Models/PlanningParticipant.swift
@@ -12,6 +12,7 @@ public class PlanningParticipant: Codable, Identifiable {
     public private(set) var id: String
     public private(set) var name: String
     public var selectedCard: PlanningCard? = nil
+    public var skipped: Bool? = false
     
     public init(id: String, name: String) {
         self.id = id

--- a/mamba/mamba/Networking/Commands/Planning/Models/PlanningTicketVote.swift
+++ b/mamba/mamba/Networking/Commands/Planning/Models/PlanningTicketVote.swift
@@ -10,9 +10,9 @@ import Foundation
 
 public class PlanningTicketVote: Codable {
     public private(set) var user: PlanningParticipant
-    public private(set) var selectedCard: PlanningCard
+    public private(set) var selectedCard: PlanningCard?
     
-    init(user: PlanningParticipant, selectedCard: PlanningCard) {
+    init(user: PlanningParticipant, selectedCard: PlanningCard?) {
         self.user = user
         self.selectedCard = selectedCard
     }

--- a/mamba/mamba/Networking/Commands/Planning/PlanningCommands.HostSend+Extensions.swift
+++ b/mamba/mamba/Networking/Commands/Planning/PlanningCommands.HostSend+Extensions.swift
@@ -21,6 +21,8 @@ public extension PlanningCommands.HostSend {
         switch self {
         case .startSession(let message): try container.encode(message, forKey: .message)
         case .addTicket(let message): try container.encode(message, forKey: .message)
+        case .skipVote(let message): try container.encode(message, forKey: .message)
+        case .removeParticipant(let message):  try container.encode(message, forKey: .message)
         default:
             break
         }

--- a/mamba/mamba/Networking/Commands/Planning/PlanningCommands.swift
+++ b/mamba/mamba/Networking/Commands/Planning/PlanningCommands.swift
@@ -30,8 +30,8 @@ public enum PlanningCommands {
     public enum HostSend: Encodable {
         case startSession(PlanningStartSessionMessage)
         case addTicket(PlanningAddTicketMessage)
-        case skipVote
-        case removeParticipant
+        case skipVote(PlanningSkipVoteMessage)
+        case removeParticipant(PlanningRemoveParticipantMessage)
         case endSession
         case finishVoting
         case reconnect

--- a/mamba/mamba/Planning/Host/Session Landing/ViewModels/PlanningHostSessionLandingViewModel.swift
+++ b/mamba/mamba/Planning/Host/Session Landing/ViewModels/PlanningHostSessionLandingViewModel.swift
@@ -44,6 +44,21 @@ class PlanningHostSessionLandingViewModel: PlanningSessionLandingViewModel<Plann
         closeSession()
     }
     
+    func sendFinishVotingCommand() {
+        sendCommand(.finishVoting)
+    }
+    
+    func sendSkipParticipantVoteCommand(participantId: String) {
+        let commandMessage = PlanningSkipVoteMessage(participantId: participantId)
+        sendCommand(.skipVote(commandMessage))
+    }
+    
+    func sendRemoveParticipantCommand(participantId: String) {
+        let commandMessage = PlanningRemoveParticipantMessage(participantId: participantId)
+        sendCommand(.removeParticipant(commandMessage))
+    }
+    
+    
     public override func executeCommand(_ command: PlanningCommands.HostReceive) {
         super.executeCommand(command)
         switch command {

--- a/mamba/mamba/Planning/Join/Session Landing/ViewModels/PlanningJoinSessionLandingViewModel.swift
+++ b/mamba/mamba/Planning/Join/Session Landing/ViewModels/PlanningJoinSessionLandingViewModel.swift
@@ -58,8 +58,8 @@ class PlanningJoinSessionLandingViewModel: PlanningSessionLandingViewModel<Plann
             let errorDescription = NSLocalizedString("PLANNING_INVALID_SESSION_ERROR_DESCRIPTION", comment: "Invalid session error description")
             executeError(code: errorCode, description: errorDescription)
         case .removeParticipant:
-            // TODO: MAM-63
-            break
+            dismiss = true
+            closeSession()
         case .endSession:
             dismiss = true
             closeSession()

--- a/mamba/mamba/Planning/Shared/ViewModels/PlanningParticipantRowViewModel.swift
+++ b/mamba/mamba/Planning/Shared/ViewModels/PlanningParticipantRowViewModel.swift
@@ -10,6 +10,7 @@ import Foundation
 import UIKit
 
 class PlanningParticipantRowViewModel: Identifiable {
+    let participantId: String
     let participantName: String
     let votingValue: String?
     let votingImageName: String?
@@ -19,7 +20,8 @@ class PlanningParticipantRowViewModel: Identifiable {
         highlighted ? 2 : 0
     }
     
-    init(participantName: String, votingValue: String? = nil, votingImageName: String? = nil, highlighted: Bool = false) {
+    init(participantId: String, participantName: String, votingValue: String? = nil, votingImageName: String? = nil, highlighted: Bool = false) {
+        self.participantId = participantId
         self.participantName = participantName
         self.votingValue = votingValue
         self.highlighted = highlighted

--- a/mamba/mamba/Planning/Shared/Views/PlanningFinishedVotingStateGraphCardView.swift
+++ b/mamba/mamba/Planning/Shared/Views/PlanningFinishedVotingStateGraphCardView.swift
@@ -19,19 +19,39 @@ struct PlanningFinishedVotingStateGraphCardView: View {
                 .multilineTextAlignment(.center)
                 .padding(leading: 20, top: 15, trailing: 20)
             
-            HorizontalCombinedBarGraphView(barGraphEntries: self.barGraphEntries, barWidth: UIScreen.main.bounds.width - 70)
-                .padding(leading: 20, top: 15, bottom: 20, trailing: 20)
-                .frame(maxWidth: .infinity)
+            if self.barGraphEntries.count > 0 {
+                HorizontalCombinedBarGraphView(barGraphEntries: self.barGraphEntries, barWidth: UIScreen.main.bounds.width - 70)
+                    .padding(leading: 20, top: 15, bottom: 20, trailing: 20)
+                    .frame(maxWidth: .infinity)
+            } else {
+                Text("PLANNING_VOTING_FINISHED_NO_VOTES_DESCRIPTION")
+                    .font(.system(size: 16))
+                    .fontWeight(.light)
+                    .multilineTextAlignment(.center)
+                    .padding(leading: 20, top: 15, bottom: 20, trailing: 20)
+                    .frame(maxWidth: .infinity)
+            }
         }
     }
 }
 
 struct PlanningFinishedVotingStateGraphCardView_Previews: PreviewProvider {
     static var previews: some View {
-        PlanningFinishedVotingStateGraphCardView(barGraphEntries: [
-            CombinedBarGraphEntry(title: "5", count: 10),
-            CombinedBarGraphEntry(title: "1", count: 2),
-            CombinedBarGraphEntry(title: "3", count: 1)
-        ])
+        Group {
+            PlanningFinishedVotingStateGraphCardView(barGraphEntries: [
+                CombinedBarGraphEntry(title: "5", count: 10),
+                CombinedBarGraphEntry(title: "1", count: 2),
+                CombinedBarGraphEntry(title: "3", count: 1)
+            ])
+                .environment(\.colorScheme, .light)
+                .previewDisplayName("Light mode")
+                .padding()
+            
+            PlanningFinishedVotingStateGraphCardView(barGraphEntries: [])
+                .environment(\.colorScheme, .dark)
+                .previewDisplayName("Dark mode")
+                .padding()
+                .background(Color.black)
+        }.previewLayout(.sizeThatFits)
     }
 }

--- a/mamba/mamba/Planning/Shared/Views/PlanningParticipantRowView.swift
+++ b/mamba/mamba/Planning/Shared/Views/PlanningParticipantRowView.swift
@@ -33,7 +33,7 @@ struct PlanningParticipantRowView: View {
                 Image(systemName: self.viewModel.votingImageName!)
                     .frame(width: 26, height: 26)
                     .foregroundColor(.accentColor)
-                    .padding(top: 9, bottom: 9, trailing: 14)
+                    .padding(top: 9, bottom: 9, trailing: 10)
             }
         }
         .background(DefaultStyle.shared.systemGray5)
@@ -47,20 +47,20 @@ struct PlanningParticipantRowView: View {
 struct PlanningHostParticipantRowView_Previews: PreviewProvider {
     static var previews: some View {
         Group {
-            PlanningParticipantRowView(viewModel: PlanningParticipantRowViewModel(participantName: "Piet Pompies", votingValue: ""))
+            PlanningParticipantRowView(viewModel: PlanningParticipantRowViewModel(participantId: "", participantName: "Piet Pompies", votingValue: "100"))
                 .environment(\.colorScheme, .light)
                 .previewDisplayName("Light mode")
             
-            PlanningParticipantRowView(viewModel: PlanningParticipantRowViewModel(participantName: "Piet Pompies", votingValue: "5"))
+            PlanningParticipantRowView(viewModel: PlanningParticipantRowViewModel(participantId: "", participantName: "Piet Pompies", votingValue: "5"))
                 .environment(\.colorScheme, .dark)
                 .previewDisplayName("Dark mode")
                 .background(Color.black)
             
-            PlanningParticipantRowView(viewModel: PlanningParticipantRowViewModel(participantName: "Piet Pompies", votingValue: "", highlighted: true))
+            PlanningParticipantRowView(viewModel: PlanningParticipantRowViewModel(participantId: "", participantName: "Piet Pompies", votingImageName: "arrowshape.turn.up.right", highlighted: true))
                 .environment(\.colorScheme, .light)
                 .previewDisplayName("Light mode")
             
-            PlanningParticipantRowView(viewModel: PlanningParticipantRowViewModel(participantName: "Piet Pompies", votingValue: "5", highlighted: true))
+            PlanningParticipantRowView(viewModel: PlanningParticipantRowViewModel(participantId: "", participantName: "Piet Pompies", votingImageName: "arrowshape.turn.up.right", highlighted: true))
                 .environment(\.colorScheme, .dark)
                 .previewDisplayName("Dark mode")
                 .background(Color.black)

--- a/mamba/mamba/Resources/Localizable.strings
+++ b/mamba/mamba/Resources/Localizable.strings
@@ -54,6 +54,7 @@
 "PLANNING_ERROR_DESCRIPTION" = "The snakes are all hissing in unison!\nSomething went wrong!";
 "PLANNING_FINISHED_STATE_VOTING_RESULTS_TITLE" = "Voting results";
 "PLANNING_ADDITIONAL_ACTION_SHEET_TITLE" = "Additional actions";
+"PLANNING_VOTING_FINISHED_NO_VOTES_DESCRIPTION" = "No votes have been made.";
 
 // MARK: - Planning errors
 "PLANNING_INVALID_SESSION_ERROR_CODE" = "0001";


### PR DESCRIPTION
# iOS Pull Request
- [x] Assigned labels
- [x] Description
- [x] Screenshot
- [ ] Unit tests
- [x] Ticket: https://operation-winter.atlassian.net/browse/MAM-63 & https://operation-winter.atlassian.net/browse/MAM-64 & https://operation-winter.atlassian.net/browse/MAM-65

# Work done
Add ability to skip a vote, finish voting, and remove a participant from a session for a host.

# Screenshot
**Remove participant:**
![Screen Recording 2020-08-18 at 09 42 19](https://user-images.githubusercontent.com/52150410/90487667-12072680-e13b-11ea-97bf-6f2b9ab16b28.gif)

**Skip vote:**
![Screen Recording 2020-08-18 at 09 37 21](https://user-images.githubusercontent.com/52150410/90487760-306d2200-e13b-11ea-8bbe-9f1b4b8ac832.gif)

**Finish voting:**
![Screen Recording 2020-08-18 at 10 01 01](https://user-images.githubusercontent.com/52150410/90487619-0156b080-e13b-11ea-8b8e-88e2170aa5db.gif)
